### PR TITLE
Storing Vori API URL in provisioned defaults

### DIFF
--- a/voripos-provision.sh
+++ b/voripos-provision.sh
@@ -128,6 +128,7 @@ statusCode=$(tail -n1 <<< "$response")  # Get the status code from the last line
 content=$(sed '$ d' <<< "$response")   # Get everything except the last line (which contains the status code)
 
 environment=$( jq -r  '.metadata.environment | select( . != null )' <<< "${content}" )
+voriApiUrl=$( jq -r  '.vori_api_url | select( . != null )' <<< "${content}" )
 bannerID=$( jq -r  '.metadata.banner.id | select( . != null )' <<< "${content}" )
 bannerName=$( jq -r  '.metadata.banner.name | select( . != null )' <<< "${content}" )
 storeID=$( jq -r  '.metadata.store.id | select( . != null )' <<< "${content}" )
@@ -151,6 +152,8 @@ echo "Storing credentials..."
 mkdir -p "$HOME/voripos"
 txnKeyPath="$HOME/voripos/gcp.json"
 echo "$transactionKey" | base64 --decode > "$txnKeyPath"
+
+defaults write com.vori.VoriPOS provisioned_voriApiUrl -string "$voriApiUrl"
 
 # Metadata
 defaults write com.vori.VoriPOS provisioned_environment -string "$environment"

--- a/voripos-provision.sh
+++ b/voripos-provision.sh
@@ -4,7 +4,7 @@ set -e
 set +v
 set +x
 
-VORIPOS_PROVISION_VERSION=0.6.1
+VORIPOS_PROVISION_VERSION=0.7.0
 VORI_API_ROOT="${VORI_API_ROOT:-https://api.vori.com/v1}"
 
 Normal=$(tput sgr0)


### PR DESCRIPTION
This will help ensure the app does not need to hardcode the API URL so that we can easily test in multiple environments.

Related: https://github.com/voriteam/backend/pull/4344