### PR TITLE
Added support for downloading compressed domain databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+*.sqlite*

--- a/voripos-provision.sh
+++ b/voripos-provision.sh
@@ -4,7 +4,7 @@ set -e
 set +v
 set +x
 
-VORIPOS_PROVISION_VERSION=0.13.0
+VORIPOS_PROVISION_VERSION=0.14.0
 VORI_API_ROOT="${VORI_API_ROOT:-https://api.vori.com/v1}"
 DOMAIN_FILE_PATH="${HOME}/Library/Containers/com.vori.VoriPOS/Data/Library/Application Support/Domain"
 
@@ -226,7 +226,7 @@ if [ $downloadDomainDb = true ] ; then
   # Download domain database to application support
   fileTimestamp=$(date +%s)
   dbPath="${DOMAIN_FILE_PATH}/${fileTimestamp}-Domain.sqlite3"
-  curl --silent -o "$dbPath" "$downloadUrl"
+  curl --silent --compressed -o "$dbPath" "$downloadUrl"
 
   actualAlgorithm="sha512"
   actualHash=$(sha512sum "$dbPath" | cut -d " " -f 1)


### PR DESCRIPTION
The server will soon support compressing databases with gzip. The cURL client has been updated to send the appropriate headers and decompress locally.

Related: https://github.com/voriteam/backend/pull/4690